### PR TITLE
fix: 移除对 NHotkey.Wpf 的依赖

### DIFF
--- a/Ink Canvas/InkCanvasForClass.csproj
+++ b/Ink Canvas/InkCanvasForClass.csproj
@@ -137,7 +137,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NHotkey.Wpf" Version="3.0.0" />
     <PackageReference Include="OSVersionExt" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
fix: 移除对 NHotkey.Wpf 的依赖

从项目文件 `InkCanvasForClass.csproj` 中移除了对 `NHotkey.Wpf` 包的引用，项目不再依赖于该版本 3.0.0。其他包的引用保持不变。

#### PR Classification
移除不再需要的依赖项。

#### PR Summary
本次提交从项目文件中移除了对 `NHotkey.Wpf` 包的引用，简化了项目的依赖关系。 
- `InkCanvasForClass.csproj`: 移除了对 `NHotkey.Wpf` 版本 3.0.0 的引用。
